### PR TITLE
disabled autoindex for acme folder

### DIFF
--- a/templates/etc/nginx/snippets/acme.conf
+++ b/templates/etc/nginx/snippets/acme.conf
@@ -7,13 +7,9 @@
 
 # Return the ACME challenge present in the server public root.
 location ^~ /.well-known/acme-challenge/ {
+  autoindex off;
   default_type "text/plain";
   try_files $uri =404;
   root {{ certbot_challenge_dir | default("/var/www/letsencrypt") }}/;
   break;
-}
-
-# Return 404 if ACME challenge well known path is accessed directly.
-location = /.well-known/acme-challenge/ {
-  return 404;
 }


### PR DESCRIPTION
disabled autoindex for acme folder which throws a 403 forbidden indead of 404 